### PR TITLE
Simplify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,33 @@ Commandline interface for [https://productive.io](https://productive.io).
 
 Install globally using yarn or npm:
 
-```
-$ npm install -g productive-cli
+```bash
+$ npm install -g
 ```
 
+```bash
+$ yarn global add
 ```
-$ yarn global add productive-cli
+
+## Usage
+
+Set the environment variables to access the productive.io API
+from user settings i.e. `https://app.productive.io/[123-org]/settings/me`
+
+```bash
+$ export PRODUCTIVE_OAUTH_TOKEN=...
+$ export PRODUCTIVE_ORGANIZATION_ID=123
+```
+
+Run the CLI:
+
+```bash
+$ productive
+```
+
+Or install and run the CLI locally:
+
+```bash
+$ npm install
+$ ./index.js
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 require('dotenv').config();
 
 const subcommander = require('subcommander');


### PR DESCRIPTION
Fixing the README instructions to suit the package which hasnt been
published yet, and add hashbang and executable bit on entrypoint
script for local usage more suited to development.